### PR TITLE
Sounds.yaml

### DIFF
--- a/Sounds.yaml
+++ b/Sounds.yaml
@@ -153,7 +153,7 @@ functions:
       
       function makeBuffer()
           local data = ""
-          datum="\0\xAD\"
+          datum="\\0\\xAD\\"
           numSamples = freq * length
           
           for i = 1,numSamples/#datum do


### PR DESCRIPTION
Edited to add some backslashes in the sound buffer example, which previously would have given an error when pasted into a project.
